### PR TITLE
parser.c: Enable unlatched mode

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -103,7 +103,7 @@ Level * getLevel(const char *buff)
 		err(EX_SOFTWARE, MALLOC_ERROR);
 
         level->number = getNumber(p, ',', LEVEL_VAL_ERROR, &p);
-        if (level->number > 7)
+        if (level->number > 8)
                 errx(EX_CONFIG, INVALID_LEVEL_ERROR, level->number);
 
         level->min_max[0] = getNumber(p, ',', LEVEL_VAL_ERROR, &p);


### PR DESCRIPTION
Some ThinkPads (T420, T430, possibly others) have the option of using the 8th level as a completely unlatched mode where the fan runs at 100%, so raise the number of levels to 8.

Another improvement might be to listen for coretemp/kernel warning via syslog(3) about the CPU getting too hot, at which point the fans should unlatch until the temperature has reached the smallest defined temperature, but that's outside the scope of this proposed change.